### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   validate:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main


### PR DESCRIPTION
Potential fix for [https://github.com/dariocurr/dariocurr.github.io/security/code-scanning/2](https://github.com/dariocurr/dariocurr.github.io/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly specify the minimum required permissions. Since the workflow merges branches (using `devmasx/merge-branch@master`), it requires `contents: write` permission. Other steps (checkout, install, test, test summary) do not require additional permissions. The best way to fix this is to add a `permissions` block at the job level (under `validate:`), specifying `contents: write`. This ensures that only this job has the necessary permissions, and the workflow does not grant excessive permissions globally.

**What to change:**  
- In `.github/workflows/validate.yml`, under the `validate:` job (line 10), add a `permissions:` block with `contents: write` before `runs-on: ubuntu-latest`.

**What is needed:**  
- No new methods, imports, or definitions are required—just a YAML block specifying permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
